### PR TITLE
Use reopenClass for static properties.

### DIFF
--- a/addon/initialize.js
+++ b/addon/initialize.js
@@ -12,11 +12,13 @@ function unwrap(input) {
 }
 
 export default function() {
-  ValidatorsMessages.reopen({
+  ValidatorsMessages.reopenClass({
     i18n: Ember.inject.service(),
     prefix: 'errors',
-    _regex: /\{{(\w+)\}}/g,
+    _regex: /\{{(\w+)\}}/g
+  });
 
+  ValidatorsMessages.reopen({
     getDescriptionFor(attribute, context = {}) {
       const key = `${this.get('prefix')}.description`;
       const i18n = this.get('i18n');


### PR DESCRIPTION
This caused a subtle bug in unit/integration testing where the i18n injection
could lose its container during test runtime. Per the guides, static properties
should be defined in a reopenClass, while shared instance methods & properties
should be defined in a reopen.
Fixes #5.
