### PR TITLE
Read i18nDescriptionKey from Validator options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export default ValidatorsMessages.extend({
 
 ### Translating Validator description
 
-To translate the description of a Validator specify the `i18nDescriptionKey` to match a key in your translations.
+To translate the description of a Validator specify the `descriptionKey` to match a key in your translations.
 
 ```js
 // app/models/user.js
@@ -76,7 +76,7 @@ import {validator, buildValidations} from 'ember-cp-validations';
 const Validations = buildValidations({
     username: validator('presence', {
         presence: true,
-        i18nDescriptionKey: 'key.for.username'
+        descriptionKey: 'key.for.username'
     })
 });
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,45 @@ export default ValidatorsMessages.extend({
 });
 ```
 
+### Translating Validator description
+
+To translate the description of a Validator specify the `i18nDescriptionKey` to match a key in your translations.
+
+```js
+// app/models/user.js
+
+import {validator, buildValidations} from 'ember-cp-validations';
+
+const Validations = buildValidations({
+    username: validator('presence', {
+        presence: true,
+        i18nDescriptionKey: 'key.for.username'
+    })
+});
+
+...
+
+// app/locales/en/translations.js
+
+export default {
+    key: {
+        for: {
+            username: 'Username'
+        }
+    }
+}
+
+// app/locales/sv/translations.js
+
+export default {
+    key: {
+        for: {
+            username: 'Användarnamn'
+        }
+    }
+}
+```
+
 ## Running
 
 * `ember server`

--- a/addon/initialize.js
+++ b/addon/initialize.js
@@ -21,8 +21,8 @@ export default function() {
       const i18n = this.get('i18n');
       let key = `${this.get('prefix')}.description`;
 
-      if (!Ember.isEmpty(options.i18nDescriptionKey)) {
-          key = options.i18nDescriptionKey;
+      if (!Ember.isEmpty(options.descriptionKey)) {
+          key = options.descriptionKey;
       } else if (!Ember.isEmpty(options.description)) {
           return options.description;
       }

--- a/addon/initialize.js
+++ b/addon/initialize.js
@@ -18,12 +18,14 @@ export default function() {
     _regex: /\{{(\w+)\}}/g,
 
     getDescriptionFor(attribute, options = {}) {
-      if (!Ember.isEmpty(options.description)) {
-        return options.description;
-      }
-
-      const key = `${this.get('prefix')}.description`;
       const i18n = this.get('i18n');
+      let key = `${this.get('prefix')}.description`;
+
+      if (!Ember.isEmpty(options.i18nDescriptionKey)) {
+          key = options.i18nDescriptionKey;
+      } else if (!Ember.isEmpty(options.description)) {
+          return options.description;
+      }
 
       if (i18n && i18n.exists(key)) {
         return unwrap(i18n.t(key, options));


### PR DESCRIPTION
Fixes #10 

Allow translation of Validator descriptions by setting `i18nDescriptionKey`. Not entirely sure about the key name.

Let me know what you think.
