### PR TITLE
Fix Handlebars.SafeString deprecation message in ember 2.8.x

### DIFF
--- a/app/initializers/ember-i18n-cp-validations.js
+++ b/app/initializers/ember-i18n-cp-validations.js
@@ -16,7 +16,7 @@ const {
 } = Ember;
 
 function isSafeString(input) {
-  return (typeof isHTMLSafe === 'function' && isHTMLSafe(input)) || (input instanceof Handlebars.SafeString);
+  return typeof isHTMLSafe === 'function' ? isHTMLSafe(input) : input instanceof Handlebars.SafeString;
 }
 
 function unwrap(input) {


### PR DESCRIPTION
Extracted from: https://github.com/workmanw/ember-string-ishtmlsafe-polyfill
Discussion here: https://github.com/emberjs/ember.js/issues/13318
