### PR TITLE
Add missing validation messages to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ export default {
     even: "{{description}} must be even",
     positive: "{{description}} must be positive",
     date: "{{description}} must be a valid date",
+    onOrAfter: '{{description}} must be on or after {{onOrAfter}}',
+    onOrBefore: '{{description} must be on or before {{onOrBefore}}',
     email: "{{description}} must be a valid email address",
     phone: "{{description}} must be a valid phone number",
     url: "{{description}} must be a valid url"


### PR DESCRIPTION
I was getting errors in my app during date validations. Now I figured out, that two messages were missing in the example. I added these lines to prevent others from having the same issue.