### PR TITLE
Fix broken localization string

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ export default {
     positive: "{{description}} must be positive",
     date: "{{description}} must be a valid date",
     onOrAfter: '{{description}} must be on or after {{onOrAfter}}',
-    onOrBefore: '{{description} must be on or before {{onOrBefore}}',
+    onOrBefore: '{{description}} must be on or before {{onOrBefore}}',
     email: "{{description}} must be a valid email address",
     phone: "{{description}} must be a valid phone number",
     url: "{{description}} must be a valid url"


### PR DESCRIPTION
Ran into this issue today which cause it tro try and replace the entire string, resulting in a blank string getting returned. Quite confusing before I found the cause.